### PR TITLE
Support for different formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 psb2.egg-info/
 BUILD_NOTES.md
+*.pyc

--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ The `fetch_examples` function downloads (if necessary) and samples training and 
  {'input1': 405789, 'output1': 'Fizz'}]
 ```
 
+Or, if you'd like your test cases in a different format, you can supply an optional `format` argument:
+
+```python
+>>> import psb2
+>>> (train_data, test_data) = psb2.fetch_examples("path/to/PSB2/datasets/", "fizz-buzz", 200, 2000, format='lists')
+>>> train_data
+[([1], ['1']),
+ ([2], ['2']),
+ ([3], ['Fizz']),
+ ([4], ['4']),
+ ...
+ ([405919], ['405919']),
+ ([405789], ['Fizz'])
+```
+
+```python
+>>> import psb2
+>>> (train_data, test_data) = psb2.fetch_examples("path/to/PSB2/datasets/", "fizz-buzz", 200, 2000, format='competitive')
+>>> train_data
+[(['1'], ['1']),
+ (['2'], ['2']),
+ (['3'], ['Fizz']),
+ (['4'], ['4']),
+ ...
+ (['405919'], ['405919']),
+ (['405789'], ['Fizz'])
+```
+
 Each example in the returned `train_data` and `test_data` lists is a map containing one key for each input and each output. `train_data` includes all defined edge cases for a problem, as well as enough randomly generated cases to fill the training set (200 in the example above). `test_data` will sample `n_test` cases from the randomly generated cases.
 
 ## Citation

--- a/psb2/__init__.py
+++ b/psb2/__init__.py
@@ -1,3 +1,5 @@
+from .format import format_test_case
+
 from .psb2 import (
     fetch_examples,
     get_problem_names,

--- a/psb2/format.py
+++ b/psb2/format.py
@@ -1,0 +1,50 @@
+import itertools
+
+def objects2lines(objects):
+    lines = []
+    for object in objects:
+        if isinstance(object, list):
+            lines.append(str(len(object)))
+            lines.append(' '.join(map(str, object)))
+        else:
+            lines.append(str(object))
+    return lines
+
+def disnumerate_prefix(data, prefix):
+    lines = []
+    for line_number in itertools.count(start=1):
+        try:
+            lines.append(data[f'{prefix}{line_number}'])
+        except KeyError:
+            break
+    return lines
+
+def format_test_case(test_case, format):
+    """
+    Represents a test case in one of 3 formats: 'psb2', 'lists' or 'competitive'
+
+    'psb2' format is a dictionary with keys 'input{i}' and 'output{i}'
+        indicating ith input and output, respectively.
+        Ex: {'input1': 1, 'input2': 2, 'output1': 'output'}
+    'lists' format is a list of tuple of the form (input, output)
+        where input and output are lists of objects.
+        Ex: [(1, 2), ('output')]
+    'competitive' format is the defacto standard format in competitive programming.
+        It has the same structure as 'lists', but all inputs and outputs are strings
+        corresponding to input and output lines
+        Besides, every array/list input/output is represented with 2 lines:
+        array length and array elements
+    """
+
+    if format == 'psb2':
+        return test_case
+    else:
+        input_objs, output_objs = (disnumerate_prefix(test_case, prefix) 
+                                   for prefix in ('input', 'output'))
+
+        if format == 'lists':
+            return (input_objs, output_objs)
+        elif format == 'competitive':
+            return (objects2lines(input_objs), objects2lines(output_objs))
+
+    raise ValueError(f'Unknown format: {format}')

--- a/psb2/psb2.py
+++ b/psb2/psb2.py
@@ -5,6 +5,8 @@ PSB2 - The Second Program Synthesis Benchmark Suite
 import os, json, random
 import requests
 
+from psb2 import format_test_case
+
 PROBLEMS = ["basement",
             "bouncing-balls",
             "bowling",
@@ -74,7 +76,7 @@ def fetch_and_possibly_cache_data(datasets_directory, problem_name, edge_or_rand
     return dataset
 
 
-def fetch_examples(datasets_directory, problem_name, n_train, n_test):
+def fetch_examples(datasets_directory, problem_name, n_train, n_test, format='psb2'):
     """Downloads, fetches, and returns training and test data from a PSB2 problem.
     Caches downloaded datasets in `datasets_directory` to avoid multiple downloads.
     Returns a tuple of the form (training_examples testing_examples)
@@ -91,7 +93,8 @@ def fetch_examples(datasets_directory, problem_name, n_train, n_test):
         `problem_name` - Name of the PSB2 problem, lowercase and seperated by dashes.
             - Ex: indices-of-substring
         `n_train` - Number of training cases to return
-        `n_test` - Number of test cases to return"""
+        `n_test` - Number of test cases to return
+        `format` - 'psb2', 'lists' or 'competitive'"""
 
     # Cannot sample more than 1 million examples for train or test
     assert n_train < 1000000, "Cannot sample more than 1 million examples"
@@ -109,6 +112,9 @@ def fetch_examples(datasets_directory, problem_name, n_train, n_test):
         train.extend(random.sample(random_data, n_train - len(edge_data)))
 
     test = random.sample(random_data, n_test)
+
+    train = [format_test_case(test_case, format) for test_case in train]
+    test = [format_test_case(test_case, format) for test_case in test]
 
     return (train, test)
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='psb2',
-    version='1.0.0',    
+    version='1.0.1',    
     description='Utilities for sampling the datasets of PSB2.',
-    author='Thomas Helmuth',
+    author='Thomas Helmuth and contributors',
     author_email='thelmuth@hamilton.edu',
     url='https://github.com/thelmuth/psb2-python',
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='psb2',
-    version='1.0.1',    
+    version='1.1.0',    
     description='Utilities for sampling the datasets of PSB2.',
     author='Thomas Helmuth and contributors',
     author_email='thelmuth@hamilton.edu',


### PR DESCRIPTION
I found the PSB2 format where a list of inputs is represented as `{'input1': 1, 'input2':2,'input3':3}` a bit inconvenient, it always requires some preprocessing before you can supply the inputs to the program you are testing. So I added some functionality to fetch data in different formats. I has no breaking changes and I beleive it could be useful to a lot of people.