### PR TITLE
Add Seeding to Random Sampling

### DIFF
--- a/psb2/psb2.py
+++ b/psb2/psb2.py
@@ -76,7 +76,7 @@ def fetch_and_possibly_cache_data(datasets_directory, problem_name, edge_or_rand
     return dataset
 
 
-def fetch_examples(datasets_directory, problem_name, n_train, n_test, format='psb2'):
+def fetch_examples(datasets_directory, problem_name, n_train, n_test, format='psb2', seed=None):
     """Downloads, fetches, and returns training and test data from a PSB2 problem.
     Caches downloaded datasets in `datasets_directory` to avoid multiple downloads.
     Returns a tuple of the form (training_examples testing_examples)
@@ -94,7 +94,8 @@ def fetch_examples(datasets_directory, problem_name, n_train, n_test, format='ps
             - Ex: indices-of-substring
         `n_train` - Number of training cases to return
         `n_test` - Number of test cases to return
-        `format` - 'psb2', 'lists' or 'competitive'"""
+        `format` - 'psb2', 'lists' or 'competitive'
+        `seed` - Seed for random. Uses default random.seed behavior if no value is provided"""
 
     # Cannot sample more than 1 million examples for train or test
     assert n_train < 1000000, "Cannot sample more than 1 million examples"
@@ -103,6 +104,9 @@ def fetch_examples(datasets_directory, problem_name, n_train, n_test, format='ps
     # Load data
     edge_data = fetch_and_possibly_cache_data(datasets_directory, problem_name, "edge")
     random_data = fetch_and_possibly_cache_data(datasets_directory, problem_name, "random")
+
+    # Seed RNG source
+    random.seed(seed)
 
     # Make training and test sets
     if n_train < len(edge_data):


### PR DESCRIPTION
Currently, there is no way to seed the random selection used to sample datasets from the fetch_examples function. For instance, two invocations of the function produce the following output using the PyPi version of PSB2:

```python
>>> psb2.fetch_examples("./", "bowling", 1, 0)
([{'input1': '--------------1-----', 'output1': 1}], [])
>>> psb2.fetch_examples("./", "bowling", 1, 0)
([{'input1': 'XXXXXXXXXXXX', 'output1': 300}], [])
```

This PR adds an optional parameter of seed to allow for repeatable sampling. Invocations using the updated version of the library produce the following output:

```python
>>> psb2.fetch_examples("./", "bowling", 1, 0, seed=1 )
([{'input1': '532/4362X179-41447/5', 'output1': 100}], [])
>>> psb2.fetch_examples("./", "bowling", 1, 0, seed=1)
([{'input1': '532/4362X179-41447/5', 'output1': 100}], [])
# using no seed still yields randomized values
>>> psb2.fetch_examples("./", "bowling", 1, 0)
([{'input1': 'XXXXXXXXXXXX', 'output1': 300}], [])
>>> psb2.fetch_examples("./", "bowling", 1, 0)
([{'input1': '11111111111111111111', 'output1': 20}], [])
```

Notably, this now creates deterministic behavior when the seed is specified.

The default value of the parameter is set to `None`, which is the inferred value within the Random package itself when no seed is manually set (see [random.py](https://svn.python.org/projects/python/trunk/Lib/random.py) for the relevant Random code. line number 99). Thus, the exclusion of the named parameter seed will maintain the current API while allowing for optional determinism in sampling to enable more easy replication of experiments and findings.
 